### PR TITLE
Hotfix latest trajectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 .env
+build/


### PR DESCRIPTION
## Summary:

- Fix method for finding latest trajectories to ensure that the /trajectories/latest endpoint returns the most recent trajectory per taxi (limited to 10 entries total).